### PR TITLE
Fix: add -m/--model option for solo download while keeping positional…

### DIFF
--- a/solo_server/commands/download_hf.py
+++ b/solo_server/commands/download_hf.py
@@ -8,10 +8,20 @@ import subprocess
 
 console = Console()
 
-def download(model: str) -> None:
+def download(
+    model_arg: str = typer.Argument(None, help="Model name or repo ID (positional)"),
+    model_opt: str = typer.Option(None, "--model", "-m", help="Model name or repo ID (option)"),
+) -> None:
     """
     Downloads a Hugging Face model using the huggingface repo id.
     """
+    # Prefer the option if provided, otherwise fallback to positional
+    model = model_opt or model_arg
+
+    if not model:
+        console.print("❌ Please provide a model name (e.g., -m meta-llama/Llama-3.2-1B-Instruct)", style="bold red")
+        raise typer.Exit(code=1)
+    
     console.print(f"🚀 Downloading model: [bold]{model}[/bold]...")
     try:
         model_path = snapshot_download(repo_id=model)


### PR DESCRIPTION
### **support (#44)**

Fix this issue https://github.com/GetSoloTech/solo-server/issues/44

Ensured the changes are backward compatible — existing commands continue to work as before.

| Command | Status | Notes |
|----------|---------|-------|
| `solo download -m meta-llama/Llama-3.2-1B-Instruct` | ✅ | new flag syntax (`-m`) |
| `solo download --model meta-llama/Llama-3.2-1B-Instruct` | ✅ | long flag syntax |
| `solo download meta-llama/Llama-3.2-1B-Instruct` | ✅ | old positional syntax |

**### LOCAL TESTING**

```
solo download -m meta-llama/Llama-3.2-1B-Instruct
🚀 Downloading model: meta-llama/Llama-3.2-1B-Instruct...
USE_POLICY.md: 100%|█████████████████████████████████████████████████████| 6.02k/6.02k [00:00<00:00, 10.0MB/s]
LICENSE.txt: 100%|███████████████████████████████████████████████████████| 7.71k/7.71k [00:00<00:00, 24.7MB/s]
generation_config.json: 100%|████████████████████████████████████████████████| 189/189 [00:00<00:00, 1.91MB/s]
config.json: 100%|███████████████████████████████████████████████████████████| 877/877 [00:00<00:00, 10.5MB/s]
.gitattributes: 100%|████████████████████████████████████████████████████| 1.52k/1.52k [00:00<00:00, 13.2MB/s]
README.md: 100%|█████████████████████████████████████████████████████████| 41.7k/41.7k [00:00<00:00, 3.87MB/s]
special_tokens_map.json: 100%|███████████████████████████████████████████████| 296/296 [00:00<00:00, 3.79MB/s]
tokenizer_config.json: 100%|█████████████████████████████████████████████| 54.5k/54.5k [00:00<00:00, 2.29MB/s]
params.json: 100%|███████████████████████████████████████████████████████████| 220/220 [00:00<00:00, 1.89MB/s]
tokenizer.json: 100%|████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 28.3MB/s]
original/tokenizer.model: 100%|██████████████████████████████████████████| 2.18M/2.18M [00:00<00:00, 3.12MB/s]
model.safetensors: 100%|█████████████████████████████████████████████████| 2.47G/2.47G [01:17<00:00, 31.9MB/s]
original/consolidated.00.pth: 100%|██████████████████████████████████████| 2.47G/2.47G [01:19<00:00, 31.2MB/s]
Fetching 13 files: 100%|██████████████████████████████████████████████████████| 13/13 [01:19<00:00,  6.15s/it]
✅ Model downloaded successfully: |██████████████████████████████████▌   | 2.25G/2.47G [01:16<00:02, 84.2MB/s]

```


```
solo download --model meta-llama/Llama-3.2-1B-Instruct
🚀 Downloading model: meta-llama/Llama-3.2-1B-Instruct...
generation_config.json: 100%|████████████████████████████████████████████████| 189/189 [00:00<00:00, 1.11MB/s]
USE_POLICY.md: 100%|█████████████████████████████████████████████████████| 6.02k/6.02k [00:00<00:00, 11.3MB/s]
LICENSE.txt: 100%|███████████████████████████████████████████████████████| 7.71k/7.71k [00:00<00:00, 4.21MB/s]
config.json: 100%|███████████████████████████████████████████████████████████| 877/877 [00:00<00:00, 7.02MB/s]
README.md: 100%|█████████████████████████████████████████████████████████| 41.7k/41.7k [00:00<00:00, 2.40MB/s]
.gitattributes: 100%|████████████████████████████████████████████████████| 1.52k/1.52k [00:00<00:00, 20.2MB/s]
params.json: 100%|███████████████████████████████████████████████████████████| 220/220 [00:00<00:00, 3.23MB/s]
special_tokens_map.json: 100%|███████████████████████████████████████████████| 296/296 [00:00<00:00, 4.95MB/s]
tokenizer_config.json: 100%|█████████████████████████████████████████████| 54.5k/54.5k [00:00<00:00, 85.2MB/s]
tokenizer.json: 100%|████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 37.7MB/s]
original/tokenizer.model: 100%|██████████████████████████████████████████| 2.18M/2.18M [00:00<00:00, 2.90MB/s]
original/consolidated.00.pth: 100%|███████████████████████████████████████| 2.47G/2.47G [00:18<00:00, 134MB/s]
model.safetensors: 100%|██████████████████████████████████████████████████| 2.47G/2.47G [00:19<00:00, 126MB/s]
Fetching 13 files: 100%|██████████████████████████████████████████████████████| 13/13 [00:19<00:00,  1.54s/it]
✅ Model downloaded successfully: ███████████████████████████████████████| 2.47G/2.47G [00:19<00:00, 81.8MB/s]
```

```
solo download meta-llama/Llama-3.2-1B-Instruct

🚀 Downloading model: meta-llama/Llama-3.2-1B-Instruct...
generation_config.json: 100%|█████████████████████████████████████████████████| 189/189 [00:00<00:00, 465kB/s]
LICENSE.txt: 100%|███████████████████████████████████████████████████████| 7.71k/7.71k [00:00<00:00, 9.18MB/s]
USE_POLICY.md: 100%|█████████████████████████████████████████████████████| 6.02k/6.02k [00:00<00:00, 7.66MB/s]
.gitattributes: 100%|████████████████████████████████████████████████████| 1.52k/1.52k [00:00<00:00, 1.28MB/s]
config.json: 100%|███████████████████████████████████████████████████████████| 877/877 [00:00<00:00, 5.85MB/s]
README.md: 100%|█████████████████████████████████████████████████████████| 41.7k/41.7k [00:00<00:00, 2.55MB/s]
special_tokens_map.json: 100%|███████████████████████████████████████████████| 296/296 [00:00<00:00, 3.36MB/s]
tokenizer_config.json: 100%|█████████████████████████████████████████████| 54.5k/54.5k [00:00<00:00, 2.67MB/s]
params.json: 100%|███████████████████████████████████████████████████████████| 220/220 [00:00<00:00, 1.13MB/s]
tokenizer.json: 100%|████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 27.3MB/s]
original/tokenizer.model: 100%|██████████████████████████████████████████| 2.18M/2.18M [00:00<00:00, 3.56MB/s]
model.safetensors: 100%|██████████████████████████████████████████████████| 2.47G/2.47G [00:12<00:00, 191MB/s]
original/consolidated.00.pth: 100%|███████████████████████████████████████| 2.47G/2.47G [00:13<00:00, 182MB/s]
Fetching 13 files: 100%|██████████████████████████████████████████████████████| 13/13 [00:14<00:00,  1.09s/it]
✅ Model downloaded successfully: |████████████████████████████████████▋  | 2.33G/2.47G [00:09<00:00, 244MB/s]

```