### PR TITLE
Fix renaming map in recording.py for quick setup

### DIFF
--- a/solo/commands/robots/lerobot/recording.py
+++ b/solo/commands/robots/lerobot/recording.py
@@ -1131,6 +1131,10 @@ def training_mode(config: dict):
             wandb=wandb_config,
             seed=1000,
             resume=resume_training,  # Use the resume flag we determined above
+            rename_map={
+                "observation.images.side": "observation.images.camera1",
+                "observation.images.up": "observation.images.camera2"
+            },
         )
         
         typer.echo("🎓 Starting training... This may take a while.")


### PR DESCRIPTION
## Issue

When running:
```
solo robo --train 
```

with these arguments:
- dataset_repo_id: lerobot/svla_so101_pickplace
- output_dir: outputs/train/lerobot_svla_so101_pickplace_smolvla
- policy_type: smolvla
- training_args: 6 items

After initial setup, the following error occurs:
```
❌ Training failed: Feature mismatch between dataset/environment and policy config.
- Missing features: ['observation.images.camera1', 'observation.images.camera2', 'observation.images.camera3']
- Extra features: ['observation.images.side', 'observation.images.up']
Please ensure your dataset and policy use consistent feature names.
If your dataset uses different observation keys (e.g., cameras named differently), use the `--rename_map` argument, for example:
  --rename_map='{"observation.images.left": "observation.images.camera1", "observation.images.top": "observation.images.camera2"}'
🔍 Full error traceback:
Traceback (most recent call last):
  File "/Users/silence/research/.venv/lib/python3.13/site-packages/solo/commands/robots/lerobot/recording.py", line 1154, in training_mode
    train(train_config)
    ~~~~~^^^^^^^^^^^^^^
  File "/Users/silence/research/.venv/lib/python3.13/site-packages/lerobot/configs/parser.py", line 233, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
  File "/Users/silence/research/.venv/lib/python3.13/site-packages/lerobot/scripts/lerobot_train.py", line 203, in train
    policy = make_policy(
        cfg=cfg.policy,
        ds_meta=dataset.meta,
        rename_map=cfg.rename_map,
    )
  File "/Users/silence/research/.venv/lib/python3.13/site-packages/lerobot/policies/factory.py", line 429, in make_policy
    raise ValueError(
    ...<8 lines>...
    )
ValueError: Feature mismatch between dataset/environment and policy config.
- Missing features: ['observation.images.camera1', 'observation.images.camera2', 'observation.images.camera3']
- Extra features: ['observation.images.side', 'observation.images.up']
Please ensure your dataset and policy use consistent feature names.
If your dataset uses different observation keys (e.g., cameras named differently), use the `--rename_map` argument, for example:
  --rename_map='{"observation.images.left": "observation.images.camera1", "observation.images.top": "observation.images.camera2"}'
Please check your dataset and configuration.
```

## Solution

Add the following rename configuration to the `TrainPipelineConfig` in solo-cli/solo/commands/robots/lerobot/recording.py:

```python
rename_map={
    "observation.images.side": "observation.images.camera1",
    "observation.images.up": "observation.images.camera2"
}
```

This resolves the feature name mismatch and allows training to proceed successfully.