### PR TITLE
feat: add daily clone and view count tracking via GitHub Actions

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -1,0 +1,90 @@
+name: Traffic Data Update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-traffic:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate gh CLI
+        run: echo "${{ secrets.SECRET_TOKEN }}" | gh auth login --with-token
+
+      - name: Fetch clone data
+        run: |
+          curl --user "${{ github.actor }}:${{ secrets.SECRET_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/traffic/clones \
+            > clones.json
+
+      - name: Fetch view data
+        run: |
+          curl --user "${{ github.actor }}:${{ secrets.SECRET_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/traffic/views \
+            > views.json
+
+      - name: Create or fetch gist
+        id: gist
+        run: |
+          if gh secret list | grep -q "GIST_ID"; then
+            echo "GIST_ID found"
+            GIST_ID="${{ secrets.GIST_ID }}"
+
+            HTTP_CODE=$(curl -s -o clones_before.json -w "%{http_code}" \
+              "https://gist.githubusercontent.com/${{ github.actor }}/${GIST_ID}/raw/clones.json")
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "clones.json not found in gist or gist invalid, using fresh data"
+              cp clones.json clones_before.json
+            fi
+
+            HTTP_CODE=$(curl -s -o views_before.json -w "%{http_code}" \
+              "https://gist.githubusercontent.com/${{ github.actor }}/${GIST_ID}/raw/views.json")
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "views.json not found in gist or gist invalid, using fresh data"
+              cp views.json views_before.json
+            fi
+
+            echo "GIST_ID=${GIST_ID}" >> $GITHUB_OUTPUT
+          else
+            echo "GIST_ID not found. Creating gist..."
+            GIST_ID=$(gh gist create clones.json views.json | awk -F / '{print $NF}')
+            echo "${GIST_ID}" | gh secret set GIST_ID
+            cp clones.json clones_before.json
+            cp views.json views_before.json
+            echo "GIST_ID=${GIST_ID}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Merge traffic data
+        run: |
+          python3 scripts/update_traffic.py --type clones
+          python3 scripts/update_traffic.py --type views
+
+      - name: Update gist
+        run: |
+          python3 -c "
+          import json
+          with open('clones.json') as f:
+              clones = f.read()
+          with open('views.json') as f:
+              views = f.read()
+          payload = {
+              'description': '${{ github.repository }} traffic statistics',
+              'files': {
+                  'clones.json': {'content': clones},
+                  'views.json': {'content': views}
+              }
+          }
+          with open('gist_payload.json', 'w') as f:
+              json.dump(payload, f)
+          "
+          curl -s -X PATCH \
+            --user "${{ github.actor }}:${{ secrets.SECRET_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d @gist_payload.json \
+            "https://api.github.com/gists/${{ steps.gist.outputs.GIST_ID }}" > /dev/null 2>&1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Solo CLI is a Python CLI tool for Physical AI - enabling model inference on edge hardware, robotics operations (motor control, teleoperation, training), and model deployment via Ollama, vLLM, or llama.cpp servers. It also integrates with Solo Hub for authentication and model downloads.
+
+## Development Setup
+
+```bash
+# Prerequisites: Git LFS, uv package manager
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install -e .
+```
+
+## Common Commands
+
+```bash
+# Run the CLI
+solo
+
+# Interactive setup (hardware detection, server config, saves to ~/.solo/config.json)
+solo setup
+
+# Linting/formatting (no config files - uses defaults)
+black solo/
+isort solo/
+
+# Tests
+pytest
+```
+
+## Architecture
+
+**CLI Framework:** Typer with Rich for terminal UI. Entry point is `solo/cli.py`.
+
+**Lazy-loaded commands:** All CLI commands in `solo/commands/` are imported inside function bodies in `cli.py` for startup performance. Follow this pattern when adding new commands.
+
+**Key modules:**
+
+- `solo/cli.py` - Typer command definitions (lazy imports from commands/)
+- `solo/main.py` - Setup wizard logic (hardware detection, config generation)
+- `solo/commands/` - Individual command implementations (serve, status, login, download, etc.)
+- `solo/hub/` - Solo Hub integration (auth via device code flow, API client, model caching)
+- `solo/utils/server_utils.py` - Server lifecycle management for Ollama/vLLM/llama.cpp (large file, ~1200 lines)
+- `solo/utils/hardware.py` - Hardware detection (CPU, GPU - NVIDIA/AMD/Apple Silicon, memory)
+- `solo/config/` - YAML defaults (`config.yaml`) + user JSON config (`~/.solo/config.json`)
+- `solo/commands/robots/lerobot/` - LeRobot robotics integration (calibration, teleop, recording, training, inference)
+- `solo/mcp/` - Domain-specific Model Context Protocol implementations (agriculture, education, healthcare, etc.)
+
+**Multi-platform support:** Hardware detection and server selection adapt to CUDA (NVIDIA), HIP (AMD), Metal (Apple Silicon), and CPU-only environments.
+
+**Configuration:** Two-tier system - YAML defaults in `solo/config/config.yaml`, user settings in `~/.solo/config.json`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/license/apache-2-0)
 [![PyPI Version](https://img.shields.io/pypi/v/solo-cli)](https://pypi.org/project/solo-cli/)
+[![GitHub Clones](https://img.shields.io/badge/dynamic/json?color=success&label=Clones&query=count&url=https://gist.githubusercontent.com/zeeshaan/GIST_ID/raw/clones.json&logo=github)](https://github.com/GetSoloTech/solo-cli)
+[![GitHub Views](https://img.shields.io/badge/dynamic/json?color=success&label=Views&query=count&url=https://gist.githubusercontent.com/zeeshaan/GIST_ID/raw/views.json&logo=github)](https://github.com/GetSoloTech/solo-cli)
 
 **Fastest way to deploy Physical AI on your hardware**
 

--- a/scripts/update_traffic.py
+++ b/scripts/update_traffic.py
@@ -1,0 +1,72 @@
+"""Merge fresh GitHub traffic data with historical data stored in a gist.
+
+Usage:
+    python3 update_traffic.py --type clones
+    python3 update_traffic.py --type views
+"""
+
+import argparse
+import json
+from collections import defaultdict
+
+
+def merge_traffic(data_type: str) -> None:
+    with open(f"{data_type}.json", "r") as f:
+        current = json.load(f)
+
+    with open(f"{data_type}_before.json", "r") as f:
+        historical = json.load(f)
+
+    entries = historical.get(data_type, [])
+    timestamp_index = {entry["timestamp"]: i for i, entry in enumerate(entries)}
+
+    for entry in current.get(data_type, []):
+        ts = entry["timestamp"]
+        if ts in timestamp_index:
+            entries[timestamp_index[ts]] = entry
+        else:
+            entries.append(entry)
+
+    entries.sort(key=lambda x: x["timestamp"])
+
+    # Compress old entries into monthly buckets when list grows large
+    if len(entries) > 100:
+        daily_keep = 35
+        to_compress = entries[: len(entries) - daily_keep]
+        to_keep = entries[len(entries) - daily_keep :]
+
+        monthly = defaultdict(lambda: {"count": 0, "uniques": 0})
+        for entry in to_compress:
+            month_key = entry["timestamp"][:7]
+            monthly[month_key]["count"] += entry["count"]
+            monthly[month_key]["uniques"] += entry["uniques"]
+
+        compressed = [
+            {"timestamp": month, "count": vals["count"], "uniques": vals["uniques"]}
+            for month, vals in sorted(monthly.items())
+        ]
+        entries = compressed + to_keep
+
+    total_count = sum(e["count"] for e in entries)
+    total_uniques = sum(e["uniques"] for e in entries)
+
+    result = {
+        data_type: entries,
+        "count": total_count,
+        "uniques": total_uniques,
+    }
+
+    with open(f"{data_type}.json", "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge GitHub traffic data")
+    parser.add_argument(
+        "--type",
+        required=True,
+        choices=["clones", "views"],
+        help="Type of traffic data to merge",
+    )
+    args = parser.parse_args()
+    merge_traffic(args.type)


### PR DESCRIPTION
Adds a workflow that fetches traffic data from GitHub API daily, accumulates it in a GitHub Gist to overcome the 14-day data limit, and displays totals via shields.io dynamic badges in the README.